### PR TITLE
Vietnam Assembly -- Add scraped page archive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby "2.0.0"
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby", branch: "morph_defaults"
+gem "scraperwiki", github: "openaustralia/scraperwiki-ruby", branch: "morph_defaults"
 gem "execjs"
 gem "pry"
 gem "colorize"

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,11 @@
 # Find out more: https://morph.io/documentation/ruby
 
 source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby "2.0.0"
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
+gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby", branch: "morph_defaults"
 gem "execjs"
 gem "pry"
 gem "colorize"

--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,18 @@
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby "2.0.0"
+ruby '2.0.0'
 
-gem "scraperwiki", github: "openaustralia/scraperwiki-ruby", branch: "morph_defaults"
-gem "execjs"
-gem "pry"
-gem "colorize"
-gem "nokogiri"
-gem "open-uri-cached"
-gem "fuzzy_match"
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
+                   branch: 'morph_defaults'
+gem 'execjs'
+gem 'pry'
+gem 'colorize'
+gem 'nokogiri'
+gem 'open-uri-cached'
+gem 'fuzzy_match'
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
 gem 'scraped_page_archive'

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
+gem 'scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/openaustralia/scraperwiki-ruby.git
+  remote: https://github.com/openaustralia/scraperwiki-ruby
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
   specs:
@@ -10,8 +10,13 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    ast (2.3.0)
     coderay (1.1.0)
     colorize (0.7.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     excon (0.45.4)
     execjs (2.5.2)
     faraday (0.9.1)
@@ -19,22 +24,49 @@ GEM
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     fuzzy_match (2.1.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
     hashie (3.4.2)
-    httpclient (2.6.0.1)
+    httpclient (2.8.2.4)
     method_source (0.8.2)
     mini_portile (0.6.2)
     multipart-post (2.0.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     open-uri-cached (0.0.5)
+    parser (2.3.1.4)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.4)
+    rainbow (2.1.0)
+    rubocop (0.45.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
+    safe_yaml (1.0.4)
+    scraped_page_archive (0.5.0)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
     slop (3.6.0)
-    sqlite3 (1.3.10)
-    sqlite_magic (0.0.3)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
       sqlite3
+    unicode-display_width (1.1.1)
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     wikidata-client (0.0.7)
       excon (~> 0.40)
       faraday (~> 0.9)
@@ -51,5 +83,13 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  rubocop
+  scraped_page_archive
   scraperwiki!
   wikidata-client (~> 0.0.7)
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/openaustralia/scraperwiki-ruby
+  remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
   specs:
@@ -12,7 +12,6 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    ast (2.3.0)
     coderay (1.1.0)
     colorize (0.7.7)
     crack (0.4.3)
@@ -34,22 +33,11 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     open-uri-cached (0.0.5)
-    parser (2.3.1.4)
-      ast (~> 2.2)
-    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.4)
-    rainbow (2.1.0)
-    rubocop (0.45.0)
-      parser (>= 2.3.1.1, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     scraped_page_archive (0.5.0)
       git (~> 1.3.0)
@@ -58,7 +46,6 @@ GEM
     sqlite3 (1.3.12)
     sqlite_magic (0.0.6)
       sqlite3
-    unicode-display_width (1.1.1)
     vcr (3.0.3)
     vcr-archive (0.3.0)
       vcr (~> 3.0.2)
@@ -83,7 +70,6 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
-  rubocop
   scraped_page_archive
   scraperwiki!
   wikidata-client (~> 0.0.7)

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,8 +5,9 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'colorize'
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 class String
   def tidy


### PR DESCRIPTION
Although the country held an election in May 2016 the source website still lists the members of the 13th congress (2011-2016). We're archiving this term now in case they disappear. (Note: The [homepage](http://dbqh.na.gov.vn/Default.aspx) purports to link to other terms -- or at least that's how I understand it -- but we're only given a list of term 13 members).

The site also lists committee members. We should make sure that these pages are archived. I have opened up an [issue](https://github.com/everypolitician/everypolitician-data/issues/20976) for this.

## [Adding Archiving to Scraper checklist](https://github.com/everypolitician/everypolitician/wiki/Adding-Archiving-to-Scraper-checklist)
* [x] 1. we are using at least version 0.5 of scraped-page-archive-gem?
* [x] 2. scraper uses scraped-page-archive gem directly or via a suitable strategy?
* [ ] 3. MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured? (@tmtmtm This will need to be set.)
* [x] 4. pages are being archived in new branch of correct scraper repo?

## [Scraper Change checklist](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)
* [ ] 1. scraper is on Morph.io under the "everypolitician-scrapers" group? (No. It currently lives at https://morph.io/tmtmtmtm/vietnam-national-assembly-members)
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [x] 3. scraper is set to auto-run?
* [x] 4. scraper is archiving?
* [x] 5. legislature has a scraper webhook set? (The legislature has a Wikidata scraper.)

## [Gemfile checklist](https://github.com/everypolitician/everypolitician/wiki/Gemfile-checklist/)
* [x] 1. all links are secure
* [x] 2. links to Github use `github:` protocol, not simply `git:`
* [x] 3. formatting is consistent with our normal Rubocop setup