### PR TITLE
Set up rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+AllCops:
+  Exclude:
+    - 'Vagrantfile'
+    - 'vendor/**/*'
+  TargetRubyVersion: 2.3
+
+inherit_from: 
+  - https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/.rubocop_base.yml
+  - .rubocop_todo.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 2.3.3
+sudo: false
+cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # It's easy to add more libraries or choose different versions. Any libraries
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby '2.0.0'
+ruby '2.3.3'
 
 gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,38 +12,38 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    coderay (1.1.0)
-    colorize (0.7.7)
+    coderay (1.1.1)
+    colorize (0.8.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    excon (0.45.4)
-    execjs (2.5.2)
-    faraday (0.9.1)
+    excon (0.55.0)
+    execjs (2.7.0)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware (0.11.0.1)
+      faraday (>= 0.7.4, < 1.0)
     fuzzy_match (2.1.0)
     git (1.3.0)
-    hashdiff (0.3.0)
-    hashie (3.4.2)
-    httpclient (2.8.2.4)
+    hashdiff (0.3.2)
+    hashie (3.5.5)
+    httpclient (2.8.3)
     method_source (0.8.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.1.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.7.0.1)
+      mini_portile2 (~> 2.1.0)
     open-uri-cached (0.0.5)
-    pry (0.10.1)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    public_suffix (2.0.4)
+    public_suffix (2.0.5)
     safe_yaml (1.0.4)
     scraped_page_archive (0.5.0)
       git (~> 1.3.0)
       vcr-archive (~> 0.3.0)
     slop (3.6.0)
-    sqlite3 (1.3.12)
+    sqlite3 (1.3.13)
     sqlite_magic (0.0.6)
       sqlite3
     vcr (3.0.3)
@@ -54,7 +54,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    wikidata-client (0.0.7)
+    wikidata-client (0.0.10)
       excon (~> 0.40)
       faraday (~> 0.9)
       faraday_middleware (~> 0.9)
@@ -75,7 +75,7 @@ DEPENDENCIES
   wikidata-client (~> 0.0.7)
 
 RUBY VERSION
-   ruby 2.0.0p648
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.5
+   1.13.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+require 'rubocop/rake_task'
+
+task default: %w(rubocop)

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,5 +1,6 @@
 #!/bin/env ruby
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'scraperwiki'
 require 'nokogiri'
@@ -11,7 +12,7 @@ require 'scraped_page_archive/open-uri'
 
 class String
   def tidy
-    self.gsub(/[[:space:]]+/, ' ').strip
+    gsub(/[[:space:]]+/, ' ').strip
   end
 end
 
@@ -45,27 +46,26 @@ def scrape_list(url)
   noko.xpath('//div[@class="ds-list"]//table//tr[td]').each do |tr|
     tds = tr.css('td')
     person_link = URI.encode tds[1].css('a/@href').text
-    data = { 
-      id: File.basename(person_link,'.*'),
-      name: tds[1].text.tidy,
-      birth_date: '%d-%02d-%02d' % tds[2].text.tidy.split("/").reverse,
-      gender: gender_from(tds[3].text.tidy),
-      area: tds[4].text.tidy,
-      source: person_link,
-      term: '13',
+    data = {
+      id:         File.basename(person_link, '.*'),
+      name:       tds[1].text.tidy,
+      birth_date: '%d-%02d-%02d' % tds[2].text.tidy.split('/').reverse,
+      gender:     gender_from(tds[3].text.tidy),
+      area:       tds[4].text.tidy,
+      source:     person_link,
+      term:       '13',
     }.merge(scrape_person(person_link))
-    ScraperWiki.save_sqlite([:id, :term], data)
+    ScraperWiki.save_sqlite(%i(id term), data)
   end
 
-  unless (next_page = noko.css('ul.paging a.next/@href').text).empty?
-    scrape_list(next_page)
-  end
+  next_page = noko.css('ul.paging a.next/@href').text
+  scrape_list(next_page) unless next_page.empty?
 end
 
 def scrape_person(url)
   noko = noko_for(url)
-  data = { 
-    image: noko.css('img.img-detail/@src').text
+  {
+    image: noko.css('img.img-detail/@src').text,
   }
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -10,7 +10,8 @@ require 'pry'
 # OpenURI::Cache.cache_path = '.cache'
 require 'scraped_page_archive/open-uri'
 
-# TODO: Remove this line when refactoring
+# TODO: Remove this line when refactoring. The metrics have been disabled
+# as a temporary fix to allow the existing code to pass.
 # rubocop:disable Metrics/MethodLength, Metrics/BlockLength, Metrics/AbcSize
 
 class String

--- a/scraper.rb
+++ b/scraper.rb
@@ -10,6 +10,9 @@ require 'pry'
 # OpenURI::Cache.cache_path = '.cache'
 require 'scraped_page_archive/open-uri'
 
+# TODO: Remove this line when refactoring
+# rubocop:disable Metrics/MethodLength, Metrics/BlockLength, Metrics/AbcSize
+
 class String
   def tidy
     gsub(/[[:space:]]+/, ' ').strip


### PR DESCRIPTION
Configures the repo for automatic rubocop tests.

I've tidied the Gemfile and the Scraper so that rubocop passes. I've also disabled line length, abc size and block length metrics so that the tests pass against the current version. I've done so by adding a comment in `scraper.rb`:

```
# TODO: Remove this line when refactoring
# rubocop:disable Metrics/MethodLength, Metrics/BlockLength, Metrics/AbcSize
```

I've disabled the metrics in line, rather than in the TODO file, as I think it is more visible. The metrics are only disabled as a temporary fix. Whoever refactors the scraper will see the comment and can decided to remove it.